### PR TITLE
Direct USB access

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,17 +66,17 @@ Sample usage:
 
 ### visualize-storage
 
-**visualize-storage** reads a dump of a GP2040-CE board's flash storage section, where the configuration lives, and
-prints it out for visual inspection or diffing with other tools. It can also find the storage section from a GP2040-CE
-whole board dump, if you have that instead. Usage is simple; just pass the tool your binary file to analyze along with
-the path to the Protobuf files.
+**visualize-storage** reads a GP2040-CE board's configuration, either over USB or from a dump of the board's flash
+storage section, and prints it out for visual inspection or diffing with other tools. It can also find the storage
+section from a GP2040-CE whole board dump, if you have that instead. Usage is simple; just connect your board in BOOTSEL
+mode or pass the tool your binary file to analyze along with the path to the Protobuf files.
 
 Because Protobuf relies on .proto files to convey the serialized structure, you must supply them from the main GP2040-CE
 project, e.g. pointing this tool at your clone of the core project. Something like this would suffice for a working
 invocation (note: you do not need to compile the files yourself):
 
 ```
-% visualize-storage -P ~/proj/GP2040-CE/proto -P ~/proj/GP2040-CE/lib/nanopb/generator/proto memory.bin
+% visualize-storage -P ~/proj/GP2040-CE/proto -P ~/proj/GP2040-CE/lib/nanopb/generator/proto --filename memory.bin
 ```
 
 (In the future we will look into publishing complete packages that include the compiled `_pb2.py` files, so that you
@@ -85,7 +85,7 @@ don't need to provide them yourself.)
 Sample output:
 
 ```
-% visualize-storage -P ~/proj/GP2040-CE/proto -P ~/proj/GP2040-CE/lib/nanopb/generator/proto ~/proj/GP2040-CE/demo-memory.bin
+% visualize-storage -P ~/proj/GP2040-CE/proto -P ~/proj/GP2040-CE/lib/nanopb/generator/proto --usb
 boardVersion: "v0.7.2"
 gamepadOptions {
   inputMode: INPUT_MODE_HID
@@ -152,8 +152,9 @@ forcedSetupOptions {
 
 ### Dumping the GP2040-CE board
 
-These tools require a dump of your GP2040-CE board, either the storage section or the whole board, depending on the
-context. The storage section of a GP2040-CE board is a reserved 8 KB starting at `0x101FE000`. To dump your board's storage:
+Some of these tools require a dump of your GP2040-CE board, either the storage section or the whole board, depending on
+the context. The storage section of a GP2040-CE board is a reserved 8 KB starting at `0x101FE000`. To dump your board's
+storage:
 
 ```
 % picotool save -r 101FE000 10200000 memory.bin

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ In all cases, online help can be retrieved by providing the `-h` or ``--help`` f
 [![asciicast](https://asciinema.org/a/67hELtUNkKCit4dFwYeAUa2fo.svg)](https://asciinema.org/a/67hELtUNkKCit4dFwYeAUa2fo)
 
 A terminal UI config editor, capable of viewing and editing existing configurations, can be launched via
-`edit-config`. It supports navigation both via the keyboard or the mouse, and can either view and edit a binary file
-made via `picotool`, or view the configuration directly on the board in BOOTSEL mode over USB (editing coming soon).
+`edit-config`. It supports navigation both via the keyboard or the mouse, and can view and edit either a binary file
+made via `picotool` or configuration directly on the board in BOOTSEL mode over USB.
 
 Simple usage:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In all cases, online help can be retrieved by providing the `-h` or ``--help`` f
 [![asciicast](https://asciinema.org/a/67hELtUNkKCit4dFwYeAUa2fo.svg)](https://asciinema.org/a/67hELtUNkKCit4dFwYeAUa2fo)
 
 A terminal UI config editor, capable of viewing and editing existing configurations, can be launched via
-**edit-config**. It supports navigation both via the keyboard or the mouse, and can either view and edit a binary file
+`edit-config`. It supports navigation both via the keyboard or the mouse, and can either view and edit a binary file
 made via `picotool`, or view the configuration directly on the board in BOOTSEL mode over USB (editing coming soon).
 
 Simple usage:
@@ -53,7 +53,7 @@ A quick demonstration of the editor is available [on asciinema.org](https://asci
 
 ### concatenate
 
-**concatenate** combines a GP2040-CE firmware .bin file (such as from a fresh build) and a GP2040-CE board's storage
+`concatenate` combines a GP2040-CE firmware .bin file (such as from a fresh build) and a GP2040-CE board's storage
 section .bin or config (with footer) .bin, and produces a properly-offset .bin file suitable for flashing to a board.
 This may be useful to ensure the board is flashed with a particular configuration, for instances such as producing a
 binary to flash many boards with a particular configuration (specific customizations, etc.), or keeping documented
@@ -65,9 +65,20 @@ Sample usage:
 % concatenate build/GP2040-CE_foo_bar.bin storage-dump.bin new-firmware-with-config.bin
 ```
 
+### dump-config
+
+`dump-config` replaces the need for picotool in order to make a copy of the GP2040-CE configuration as a binary file.
+This could be used with the other tools, or just to keep a backup.
+
+Sample usage:
+
+```
+% dump-config -P ~/proj/GP2040-CE/proto -P ~/proj/GP2040-CE/lib/nanopb/generator/proto --filename `date +%Y%m%d`-config-backup.bin
+```
+
 ### visualize-storage
 
-**visualize-storage** reads a GP2040-CE board's configuration, either over USB or from a dump of the board's flash
+`visualize-storage` reads a GP2040-CE board's configuration, either over USB or from a dump of the board's flash
 storage section, and prints it out for visual inspection or diffing with other tools. It can also find the storage
 section from a GP2040-CE whole board dump, if you have that instead. Usage is simple; just connect your board in BOOTSEL
 mode or pass the tool your binary file to analyze along with the path to the Protobuf files.
@@ -151,11 +162,13 @@ forcedSetupOptions {
 }
 ```
 
-### Dumping the GP2040-CE board
+## Miscellaneous
+
+### Dumping the GP2040-CE board with picotool
 
 Some of these tools require a dump of your GP2040-CE board, either the storage section or the whole board, depending on
 the context. The storage section of a GP2040-CE board is a reserved 8 KB starting at `0x101FE000`. To dump your board's
-storage:
+storage with picotool:
 
 ```
 % picotool save -r 101FE000 10200000 memory.bin

--- a/README.md
+++ b/README.md
@@ -24,12 +24,17 @@ currently the expectation is that you can run it yourself before invoking these 
 % pip install -Ur requirements/requirements-dev.txt
 ```
 
+## Tools
+
+In all cases, online help can be retrieved by providing the `-h` or ``--help`` flags to the below programs.
+
 ## Config Editor
 
 [![asciicast](https://asciinema.org/a/67hELtUNkKCit4dFwYeAUa2fo.svg)](https://asciinema.org/a/67hELtUNkKCit4dFwYeAUa2fo)
 
 A terminal UI config editor, capable of viewing and editing existing configurations, can be launched via
-**edit-config**. It supports navigation both via the keyboard or the mouse.
+**edit-config**. It supports navigation both via the keyboard or the mouse, and can either view and edit a binary file
+made via `picotool`, or view the configuration directly on the board in BOOTSEL mode over USB (editing coming soon).
 
 Simple usage:
 
@@ -45,10 +50,6 @@ Simple usage:
 | Q                     | Quit without saving                                    |
 
 A quick demonstration of the editor is available [on asciinema.org](https://asciinema.org/a/67hELtUNkKCit4dFwYeAUa2fo).
-
-## Tools
-
-In all cases, online help can be retrieved by providing the `-h` or ``--help`` flags to the below programs.
 
 ### concatenate
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ currently the expectation is that you can run it yourself before invoking these 
 
 In all cases, online help can be retrieved by providing the `-h` or ``--help`` flags to the below programs.
 
-## Config Editor
+### Config Editor
 
 [![asciicast](https://asciinema.org/a/67hELtUNkKCit4dFwYeAUa2fo.svg)](https://asciinema.org/a/67hELtUNkKCit4dFwYeAUa2fo)
 

--- a/gp2040ce_bintools/builder.py
+++ b/gp2040ce_bintools/builder.py
@@ -117,6 +117,7 @@ def write_new_config_to_filename(config: Message, filename: str, inject: bool = 
 # COMMANDS #
 ############
 
+
 def concatenate():
     """Combine a built firmware .bin and a storage .bin."""
     parser = argparse.ArgumentParser(

--- a/gp2040ce_bintools/builder.py
+++ b/gp2040ce_bintools/builder.py
@@ -6,7 +6,7 @@ import logging
 from google.protobuf.message import Message
 
 from gp2040ce_bintools import core_parser
-from gp2040ce_bintools.storage import (STORAGE_LOCATION, STORAGE_SIZE, pad_config_to_storage_size,
+from gp2040ce_bintools.storage import (STORAGE_BINARY_LOCATION, STORAGE_SIZE, pad_config_to_storage_size,
                                        serialize_config_with_footer)
 
 logger = logging.getLogger(__name__)
@@ -57,11 +57,11 @@ def pad_firmware_up_to_storage(firmware: bytes) -> bytearray:
     Raises:
         FirmwareLengthError: if the firmware is larger than the storage location
     """
-    bytes_to_pad = STORAGE_LOCATION - len(firmware)
+    bytes_to_pad = STORAGE_BINARY_LOCATION - len(firmware)
     logger.debug("firmware is length %s, padding %s bytes", len(firmware), bytes_to_pad)
     if bytes_to_pad < 0:
         raise FirmwareLengthError(f"provided firmware binary is larger than the start of "
-                                  f"storage at {STORAGE_LOCATION}!")
+                                  f"storage at {STORAGE_BINARY_LOCATION}!")
 
     return bytearray(firmware) + bytearray(b'\x00' * bytes_to_pad)
 
@@ -79,12 +79,13 @@ def replace_config_in_binary(board_binary: bytearray, config_binary: bytearray) 
     Returns:
         the resulting correctly-offset binary suitable for a GP2040-CE board
     """
-    if len(board_binary) < STORAGE_LOCATION + STORAGE_SIZE:
+    if len(board_binary) < STORAGE_BINARY_LOCATION + STORAGE_SIZE:
         # this is functionally the same, since this doesn't sanity check the firmware
         return combine_firmware_and_config(board_binary, config_binary)
     else:
         new_binary = bytearray(copy.copy(board_binary))
-        new_binary[STORAGE_LOCATION:(STORAGE_LOCATION + STORAGE_SIZE)] = pad_config_to_storage_size(config_binary)
+        new_config = pad_config_to_storage_size(config_binary)
+        new_binary[STORAGE_BINARY_LOCATION:(STORAGE_BINARY_LOCATION + STORAGE_SIZE)] = new_config
         return new_binary
 
 

--- a/gp2040ce_bintools/gui.py
+++ b/gp2040ce_bintools/gui.py
@@ -17,8 +17,7 @@ from textual.widgets.tree import TreeNode
 
 from gp2040ce_bintools import core_parser, handler
 from gp2040ce_bintools.builder import write_new_config_to_filename
-from gp2040ce_bintools.pico import get_bootsel_endpoints, read
-from gp2040ce_bintools.storage import STORAGE_MEMORY_ADDRESS, STORAGE_SIZE, get_config, get_config_from_file
+from gp2040ce_bintools.storage import get_config_from_file, get_config_from_usb
 
 logger = logging.getLogger(__name__)
 
@@ -136,9 +135,7 @@ class ConfigEditor(App):
         usb = kwargs.pop('usb', False)
         # load the config
         if usb:
-            endpoint_out, endpoint_in = get_bootsel_endpoints()
-            storage = read(endpoint_out, endpoint_in, STORAGE_MEMORY_ADDRESS, STORAGE_SIZE)
-            self.config = get_config(bytes(storage))
+            self.config, endpoint_out, endpoint_in = get_config_from_usb()
             self.source_name = (f"DEVICE ID {hex(endpoint_out.device.idVendor)}:{hex(endpoint_out.device.idProduct)} "
                                 f"on bus {endpoint_out.device.bus} address {endpoint_out.device.address}")
         else:

--- a/gp2040ce_bintools/pico.py
+++ b/gp2040ce_bintools/pico.py
@@ -32,6 +32,15 @@ PICO_COMMANDS = {
 }
 
 
+#################
+# LIBRARY ITEMS #
+#################
+
+
+class PicoAlignmentError(ValueError):
+    """Exception raised when the address provided for an operation is invalid."""
+
+
 def get_bootsel_endpoints() -> tuple[usb.core.Endpoint, usb.core.Endpoint]:
     """Retrieve the USB endpoint for purposes of interacting with a Pico in BOOTSEL mode.
 
@@ -189,6 +198,9 @@ def write(out_end: usb.core.Endpoint, in_end: usb.core.Endpoint, location: int, 
         location: memory address of where to start reading from
         content: the data to write
     """
+    if (location % 256) != 0:
+        raise PicoAlignmentError("writes must start at 256 byte boundaries, please pad or align as appropriate!")
+
     # set up the data
     command_size = 8
 

--- a/gp2040ce_bintools/pico.py
+++ b/gp2040ce_bintools/pico.py
@@ -2,27 +2,39 @@
 
 Much of this code is a partial Python implementation of picotool.
 """
+import logging
 import struct
 
 import usb.core
+
+logger = logging.getLogger(__name__)
 
 PICO_VENDOR = 0x2e8a
 PICO_PRODUCT = 0x0003
 
 PICOBOOT_CMD_STRUCT = '<LLBBxxL'
+PICOBOOT_CMD_EXCLUSIVE_ACCESS_SUFFIX_STRUCT = 'L12x'
+PICOBOOT_CMD_EXIT_XIP_SUFFIX_STRUCT = '16x'
+PICOBOOT_CMD_READ_SUFFIX_STRUCT = 'LL8x'
 PICOBOOT_CMD_REBOOT_SUFFIX_STRUCT = 'LLL4x'
 
 PICO_MAGIC = 0x431fd10b
 PICO_SRAM_END = 0x20042000
-PICO_TOKEN = 0
 # only a partial implementation...
 PICO_COMMANDS = {
+    'EXCLUSIVE_ACCESS': 0x1,
     'REBOOT': 0x2,
+    'READ': 0x4,
+    'EXIT_XIP': 0x6,
 }
 
 
-def get_bootsel_out_endpoint() -> usb.core.Endpoint:
-    """Retrieve the USB endpoint for purposes of interacting with a Pico in BOOTSEL mode."""
+def get_bootsel_endpoints() -> tuple[usb.core.Endpoint, usb.core.Endpoint]:
+    """Retrieve the USB endpoint for purposes of interacting with a Pico in BOOTSEL mode.
+
+    Returns:
+        the out and in endpoints for the BOOTSEL interface
+    """
     # get the device and claim it from whatever else might have in the kernel
     pico_device = usb.core.find(idVendor=PICO_VENDOR, idProduct=PICO_PRODUCT)
 
@@ -40,21 +52,101 @@ def get_bootsel_out_endpoint() -> usb.core.Endpoint:
     out_endpoint = usb.util.find_descriptor(pico_bootsel_interface,
                                             custom_match=lambda e: (usb.util.endpoint_direction(e.bEndpointAddress) ==
                                                                     usb.util.ENDPOINT_OUT))
-    return out_endpoint
+    in_endpoint = usb.util.find_descriptor(pico_bootsel_interface,
+                                           custom_match=lambda e: (usb.util.endpoint_direction(e.bEndpointAddress) ==
+                                                                   usb.util.ENDPOINT_IN))
+    return out_endpoint, in_endpoint
 
 
-def reboot() -> None:
-    """Reboot a Pico in BOOTSEL mode."""
-    global PICO_TOKEN
-    endpoint = get_bootsel_out_endpoint()
+def exclusive_access(out_end: usb.core.Endpoint, in_end: usb.core.Endpoint, is_exclusive: bool = True) -> None:
+    """Enable exclusive access mode on a Pico in BOOTSEL.
 
+    Args:
+        out_endpoint: the out direction USB endpoint to write to
+        in_endpoint: the in direction USB endpoint to read from
+    """
     # set up the data
-    PICO_TOKEN += 1
+    pico_token = 1
+    command_size = 1
+    transfer_len = 0
+    exclusive = 1 if is_exclusive else 0
+    payload = struct.pack(PICOBOOT_CMD_STRUCT + PICOBOOT_CMD_EXCLUSIVE_ACCESS_SUFFIX_STRUCT,
+                          PICO_MAGIC, pico_token, PICO_COMMANDS['EXCLUSIVE_ACCESS'], command_size, transfer_len,
+                          exclusive)
+    logger.debug("EXCLUSIVE_ACCESS: %s", payload)
+    out_end.write(payload)
+    _ = in_end.read(256)
+
+
+def exit_xip(out_end: usb.core.Endpoint, in_end: usb.core.Endpoint) -> None:
+    """Exit XIP on a Pico in BOOTSEL.
+
+    Args:
+        out_endpoint: the out direction USB endpoint to write to
+        in_endpoint: the in direction USB endpoint to read from
+    """
+    # set up the data
+    pico_token = 1
+    command_size = 0
+    transfer_len = 0
+    payload = struct.pack(PICOBOOT_CMD_STRUCT + PICOBOOT_CMD_EXIT_XIP_SUFFIX_STRUCT,
+                          PICO_MAGIC, pico_token, PICO_COMMANDS['EXIT_XIP'], command_size, transfer_len)
+    logger.debug("EXIT_XIP: %s", payload)
+    out_end.write(payload)
+    _ = in_end.read(256)
+
+
+def read(out_end: usb.core.Endpoint, in_end: usb.core.Endpoint, location: int, size: int) -> bytearray:
+    """Read a requested number of bytes from a Pico in BOOTSEL, starting from the specified location.
+
+    This also prepares the USB device for reading, so it expects to be able to grab
+    exclusive access.
+
+    Args:
+        out_endpoint: the out direction USB endpoint to write to
+        in_endpoint: the in direction USB endpoint to read from
+        location: memory address of where to start reading from
+        size: number of bytes to read
+    Returns:
+        the read bytes as a byte array
+    """
+    # set up the data
+    chunk_size = 256
+    command_size = 8
+
+    read_location = location
+    read_size = 0
+    content = bytearray()
+    exclusive_access(out_end, in_end, is_exclusive=True)
+    while read_size < size:
+        exit_xip(out_end, in_end)
+        pico_token = 1
+        payload = struct.pack(PICOBOOT_CMD_STRUCT + PICOBOOT_CMD_READ_SUFFIX_STRUCT,
+                              PICO_MAGIC, pico_token, PICO_COMMANDS['READ'] + 128, command_size, chunk_size,
+                              read_location, chunk_size)
+        logger.debug("READ: %s", payload)
+        out_end.write(payload)
+        res = in_end.read(chunk_size)
+        logger.debug("res: %s", res)
+        content += res
+        read_size += chunk_size
+        read_location += chunk_size
+        out_end.write(b'\xc0')
+    exclusive_access(out_end, in_end, is_exclusive=False)
+    logger.debug("final content: %s", content[:size])
+    return content[:size]
+
+
+def reboot(out_end: usb.core.Endpoint) -> None:
+    """Reboot a Pico in BOOTSEL mode."""
+    # set up the data
+    pico_token = 1
     command_size = 12
     transfer_len = 0
     boot_start = 0
     boot_end = PICO_SRAM_END
     boot_delay_ms = 500
-    endpoint.write(struct.pack(PICOBOOT_CMD_STRUCT + PICOBOOT_CMD_REBOOT_SUFFIX_STRUCT,
-                               PICO_MAGIC, PICO_TOKEN, PICO_COMMANDS['REBOOT'], command_size, transfer_len,
-                               boot_start, boot_end, boot_delay_ms))
+    out_end.write(struct.pack(PICOBOOT_CMD_STRUCT + PICOBOOT_CMD_REBOOT_SUFFIX_STRUCT,
+                              PICO_MAGIC, pico_token, PICO_COMMANDS['REBOOT'], command_size, transfer_len,
+                              boot_start, boot_end, boot_delay_ms))
+    # we don't even bother reading here because it may have already rebooted

--- a/gp2040ce_bintools/pico.py
+++ b/gp2040ce_bintools/pico.py
@@ -1,0 +1,60 @@
+"""Methods to interact with the Raspberry Pi Pico directly.
+
+Much of this code is a partial Python implementation of picotool.
+"""
+import struct
+
+import usb.core
+
+PICO_VENDOR = 0x2e8a
+PICO_PRODUCT = 0x0003
+
+PICOBOOT_CMD_STRUCT = '<LLBBxxL'
+PICOBOOT_CMD_REBOOT_SUFFIX_STRUCT = 'LLL4x'
+
+PICO_MAGIC = 0x431fd10b
+PICO_SRAM_END = 0x20042000
+PICO_TOKEN = 0
+# only a partial implementation...
+PICO_COMMANDS = {
+    'REBOOT': 0x2,
+}
+
+
+def get_bootsel_out_endpoint() -> usb.core.Endpoint:
+    """Retrieve the USB endpoint for purposes of interacting with a Pico in BOOTSEL mode."""
+    # get the device and claim it from whatever else might have in the kernel
+    pico_device = usb.core.find(idVendor=PICO_VENDOR, idProduct=PICO_PRODUCT)
+
+    if not pico_device:
+        raise ValueError("Pico board in BOOTSEL mode could not be found!")
+
+    if pico_device.is_kernel_driver_active(0):
+        pico_device.detach_kernel_driver(0)
+
+    pico_configuration = pico_device.get_active_configuration()
+    # two interfaces are present, we want the direct rather than mass storage
+    # pico_bootsel_interface = pico_configuration[(1, 0)]
+    pico_bootsel_interface = usb.util.find_descriptor(pico_configuration,
+                                                      custom_match=lambda e: e.bInterfaceClass == 0xff)
+    out_endpoint = usb.util.find_descriptor(pico_bootsel_interface,
+                                            custom_match=lambda e: (usb.util.endpoint_direction(e.bEndpointAddress) ==
+                                                                    usb.util.ENDPOINT_OUT))
+    return out_endpoint
+
+
+def reboot() -> None:
+    """Reboot a Pico in BOOTSEL mode."""
+    global PICO_TOKEN
+    endpoint = get_bootsel_out_endpoint()
+
+    # set up the data
+    PICO_TOKEN += 1
+    command_size = 12
+    transfer_len = 0
+    boot_start = 0
+    boot_end = PICO_SRAM_END
+    boot_delay_ms = 500
+    endpoint.write(struct.pack(PICOBOOT_CMD_STRUCT + PICOBOOT_CMD_REBOOT_SUFFIX_STRUCT,
+                               PICO_MAGIC, PICO_TOKEN, PICO_COMMANDS['REBOOT'], command_size, transfer_len,
+                               boot_start, boot_end, boot_delay_ms))

--- a/gp2040ce_bintools/storage.py
+++ b/gp2040ce_bintools/storage.py
@@ -184,6 +184,19 @@ def serialize_config_with_footer(config: Message) -> bytearray:
 ############
 
 
+def dump_config():
+    """Save the GP2040-CE's configuration to a binary file."""
+    parser = argparse.ArgumentParser(
+        description="Read the configuration section from a USB device and save it to a binary file.",
+        parents=[core_parser],
+    )
+    parser.add_argument('--filename', help=".bin file to save the GP2040-CE board's config section to")
+    args, _ = parser.parse_known_args()
+    config, _, _ = get_config_from_usb()
+    with open(args.filename, 'wb') as out_file:
+        out_file.write(serialize_config_with_footer(config))
+
+
 def visualize():
     """Print the contents of GP2040-CE's storage."""
     parser = argparse.ArgumentParser(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = ["bandit", "decorator", "flake8", "flake8-blind-except", "flake8-builtins"
 
 [project.scripts]
 concatenate = "gp2040ce_bintools.builder:concatenate"
+dump-config = "gp2040ce_bintools.storage:dump_config"
 edit-config = "gp2040ce_bintools.gui:edit_config"
 visualize-storage = "gp2040ce_bintools.storage:visualize"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "Brian S. Stephan", email = "bss@incorporeal.org"},
 ]
 requires-python = ">=3.9"
-dependencies = ["grpcio-tools", "textual"]
+dependencies = ["grpcio-tools", "pyusb", "textual"]
 dynamic = ["version"]
 classifiers = [
     "Environment :: Console",

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -22,7 +22,7 @@ decorator==5.1.1
     # via gp2040ce-binary-tools (pyproject.toml)
 distlib==0.3.6
     # via virtualenv
-exceptiongroup==1.1.1
+exceptiongroup==1.1.2
     # via pytest
 filelock==3.12.2
     # via
@@ -71,7 +71,7 @@ isort==5.12.0
     # via flake8-isort
 linkify-it-py==2.0.2
     # via markdown-it-py
-markdown-it-py[linkify,plugins]==2.2.0
+markdown-it-py[linkify,plugins]==3.0.0
     # via
     #   mdit-py-plugins
     #   rich
@@ -95,7 +95,7 @@ packaging==23.1
     #   tox
 pbr==5.11.1
     # via stevedore
-pip-tools==6.13.0
+pip-tools==6.14.0
     # via gp2040ce-binary-tools (pyproject.toml)
 platformdirs==3.8.0
     # via
@@ -128,6 +128,8 @@ pytest-asyncio==0.21.0
     # via gp2040ce-binary-tools (pyproject.toml)
 pytest-cov==4.1.0
     # via gp2040ce-binary-tools (pyproject.toml)
+pyusb==1.2.1
+    # via gp2040ce-binary-tools (pyproject.toml)
 pyyaml==6.0
     # via bandit
 rich==13.4.2
@@ -142,7 +144,7 @@ snowballstemmer==2.2.0
     # via pydocstyle
 stevedore==5.1.0
     # via bandit
-textual==0.28.1
+textual==0.29.0
     # via gp2040ce-binary-tools (pyproject.toml)
 tomli==2.0.1
     # via
@@ -150,6 +152,7 @@ tomli==2.0.1
     #   coverage
     #   flake8-pyproject
     #   mypy
+    #   pip-tools
     #   pyproject-api
     #   pyproject-hooks
     #   pytest
@@ -157,7 +160,7 @@ tomli==2.0.1
     #   tox
 tox==4.6.3
     # via gp2040ce-binary-tools (pyproject.toml)
-typing-extensions==4.6.3
+typing-extensions==4.7.1
     # via
     #   mypy
     #   setuptools-scm

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,7 +12,7 @@ importlib-metadata==6.7.0
     # via textual
 linkify-it-py==2.0.2
     # via markdown-it-py
-markdown-it-py[linkify,plugins]==2.2.0
+markdown-it-py[linkify,plugins]==3.0.0
     # via
     #   mdit-py-plugins
     #   rich
@@ -25,11 +25,13 @@ protobuf==4.23.3
     # via grpcio-tools
 pygments==2.15.1
     # via rich
+pyusb==1.2.1
+    # via gp2040ce-binary-tools (pyproject.toml)
 rich==13.4.2
     # via textual
-textual==0.28.1
+textual==0.29.0
     # via gp2040ce-binary-tools (pyproject.toml)
-typing-extensions==4.6.3
+typing-extensions==4.7.1
     # via textual
 uc-micro-py==1.0.2
     # via linkify-it-py

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,14 +1,15 @@
 """Tests for the image builder module."""
 import os
 import sys
+import unittest.mock as mock
 
 import pytest
 from decorator import decorator
 
 from gp2040ce_bintools import get_config_pb2
 from gp2040ce_bintools.builder import (FirmwareLengthError, combine_firmware_and_config, pad_firmware_up_to_storage,
-                                       replace_config_in_binary, write_new_config_to_filename)
-from gp2040ce_bintools.storage import get_config, get_config_footer, get_storage_section
+                                       replace_config_in_binary, write_new_config_to_filename, write_new_config_to_usb)
+from gp2040ce_bintools.storage import get_config, get_config_footer, get_storage_section, serialize_config_with_footer
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -134,3 +135,18 @@ def test_write_new_config_to_config_bin(firmware_binary, tmp_path):
     config_size, _, _ = get_config_footer(config_dump)
     assert config.boardVersion == 'v0.7.2-COOL'
     assert len(config_dump) == config_size + 12
+
+
+@with_pb2s
+def test_write_new_config_to_usb(config_binary):
+    """Test that the config can be written to USB at the proper alignment."""
+    config = get_config(config_binary)
+    serialized = serialize_config_with_footer(config)
+    end_out, end_in = mock.MagicMock(), mock.MagicMock()
+    with mock.patch('gp2040ce_bintools.builder.write') as mock_write:
+        write_new_config_to_usb(config, end_out, end_in)
+
+    # check that it got padded
+    padded_serialized = bytearray(b'\x00' * 4) + serialized
+    assert mock_write.call_args.args[2] % 256 == 0
+    assert mock_write.call_args.args[3] == padded_serialized

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,13 +2,11 @@
 import json
 import os
 import sys
-import unittest.mock as mock
 from subprocess import run
 
 from decorator import decorator
 
 from gp2040ce_bintools import __version__
-from gp2040ce_bintools.storage import get_config_from_file
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -49,17 +47,6 @@ def test_concatenate_invocation(tmpdir):
     assert out[2088960:2097152] == storage
 
 
-@with_pb2s
-def test_dump_config_invocation(tmpdir, storage_dump, config_binary):
-    """Test that dumping a config to file works."""
-    out_filename = os.path.join(tmpdir, 'out.bin')
-    with mock.patch('gp2040ce_bintools.pico.get_bootsel_endpoints', return_value=(mock.MagicMock(), mock.MagicMock())):
-        with mock.patch('gp2040ce_bintools.pico.read', return_value=storage_dump):
-            run(['dump-config', '-P', 'tests/test-files/proto-files', '--filename', out_filename])
-    new_config = get_config_from_file(out_filename)
-    assert new_config.boardVersion == "v0.7.2"
-
-
 def test_storage_dump_invocation():
     """Test that a normal invocation against a dump works."""
     result = run(['visualize-storage', '-P', 'tests/test-files/proto-files',
@@ -84,12 +71,3 @@ def test_storage_dump_json_invocation():
                  capture_output=True, encoding='utf8')
     to_dict = json.loads(result.stdout)
     assert to_dict['boardVersion'] == 'v0.7.2'
-
-
-def test_visualize_usb_invocation(storage_dump):
-    """Test that a normal invocation against a dump works."""
-    with mock.patch('gp2040ce_bintools.pico.get_bootsel_endpoints', return_value=(mock.MagicMock(), mock.MagicMock())):
-        with mock.patch('gp2040ce_bintools.pico.read', return_value=storage_dump):
-            result = run(['visualize-storage', '-P', 'tests/test-files/proto-files', '--usb'],
-                         capture_output=True, encoding='utf8')
-    assert 'boardVersion: "v0.7.2"' in result.stdout

--- a/tests/test_pico.py
+++ b/tests/test_pico.py
@@ -1,0 +1,118 @@
+"""Test operations for interfacing directly with a Pico."""
+import os
+import struct
+import sys
+import unittest.mock as mock
+from array import array
+
+from decorator import decorator
+
+import gp2040ce_bintools.pico as pico
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+@decorator
+def with_pb2s(test, *args, **kwargs):
+    """Wrap a test with precompiled pb2 files on the path."""
+    proto_path = os.path.join(HERE, 'test-files', 'pb2-files')
+    sys.path.append(proto_path)
+
+    test(*args, **kwargs)
+
+    sys.path.pop()
+    del sys.modules['config_pb2']
+
+
+def test_exclusive_access():
+    """Test that we can get exclusive access to a BOOTSEL board."""
+    end_out, end_in = mock.MagicMock(), mock.MagicMock()
+    pico.exclusive_access(end_out, end_in)
+
+    payload = struct.pack('<LLBBxxLL12x', 0x431fd10b, 1, 0x1, 1, 0, 1)
+    end_out.write.assert_called_with(payload)
+    end_in.read.assert_called_once()
+
+    end_out.reset_mock()
+    end_in.reset_mock()
+    pico.exclusive_access(end_out, end_in, is_exclusive=False)
+
+    payload = struct.pack('<LLBBxxLL12x', 0x431fd10b, 1, 0x1, 1, 0, 0)
+    end_out.write.assert_called_with(payload)
+    end_in.read.assert_called_once()
+
+
+def test_exit_xip():
+    """Test that we can exit XIP on a BOOTSEL board."""
+    end_out, end_in = mock.MagicMock(), mock.MagicMock()
+    pico.exit_xip(end_out, end_in)
+
+    payload = struct.pack('<LLBBxxL16x', 0x431fd10b, 1, 0x6, 0, 0)
+    end_out.write.assert_called_with(payload)
+    end_in.read.assert_called_once()
+
+
+def test_read():
+    """Test that we can read a memory of a BOOTSEL board in a variety of conditions."""
+    end_out, end_in = mock.MagicMock(), mock.MagicMock()
+    end_in.read.return_value = array('B', b'\x11' * 256)
+    content = pico.read(end_out, end_in, 0x101FE000, 256)
+
+    expected_writes = [
+        mock.call(struct.pack('<LLBBxxLL12x', 0x431fd10b, 1, 0x1, 1, 0, 1)),
+        mock.call(struct.pack('<LLBBxxL16x', 0x431fd10b, 1, 0x6, 0, 0)),
+        mock.call(struct.pack('<LLBBxxLLL8x', 0x431fd10b, 1, 0x84, 8, 256, 0x101FE000, 256)),
+        mock.call(b'\xc0'),
+        mock.call(struct.pack('<LLBBxxLL12x', 0x431fd10b, 1, 0x1, 1, 0, 0)),
+    ]
+    end_out.write.assert_has_calls(expected_writes)
+    assert end_in.read.call_count == 4
+    assert len(content) == 256
+
+
+def test_read_shorter_than_chunk():
+    """Test that we can read a memory of a BOOTSEL board in a variety of conditions."""
+    end_out, end_in = mock.MagicMock(), mock.MagicMock()
+    end_in.read.return_value = array('B', b'\x11' * 256)
+    content = pico.read(end_out, end_in, 0x101FE000, 128)
+
+    expected_writes = [
+        mock.call(struct.pack('<LLBBxxLL12x', 0x431fd10b, 1, 0x1, 1, 0, 1)),
+        mock.call(struct.pack('<LLBBxxL16x', 0x431fd10b, 1, 0x6, 0, 0)),
+        mock.call(struct.pack('<LLBBxxLLL8x', 0x431fd10b, 1, 0x84, 8, 256, 0x101FE000, 256)),
+        mock.call(b'\xc0'),
+        mock.call(struct.pack('<LLBBxxLL12x', 0x431fd10b, 1, 0x1, 1, 0, 0)),
+    ]
+    end_out.write.assert_has_calls(expected_writes)
+    assert end_in.read.call_count == 4
+    assert len(content) == 128
+
+
+def test_read_bigger_than_chunk():
+    """Test that we can read a memory of a BOOTSEL board in a variety of conditions."""
+    end_out, end_in = mock.MagicMock(), mock.MagicMock()
+    end_in.read.return_value = array('B', b'\x11' * 256)
+    content = pico.read(end_out, end_in, 0x101FE000, 512)
+
+    expected_writes = [
+        mock.call(struct.pack('<LLBBxxLL12x', 0x431fd10b, 1, 0x1, 1, 0, 1)),
+        mock.call(struct.pack('<LLBBxxL16x', 0x431fd10b, 1, 0x6, 0, 0)),
+        mock.call(struct.pack('<LLBBxxLLL8x', 0x431fd10b, 1, 0x84, 8, 256, 0x101FE000, 256)),
+        mock.call(b'\xc0'),
+        mock.call(struct.pack('<LLBBxxL16x', 0x431fd10b, 1, 0x6, 0, 0)),
+        mock.call(struct.pack('<LLBBxxLLL8x', 0x431fd10b, 1, 0x84, 8, 256, 0x101FE000+256, 256)),
+        mock.call(b'\xc0'),
+        mock.call(struct.pack('<LLBBxxLL12x', 0x431fd10b, 1, 0x1, 1, 0, 0)),
+    ]
+    end_out.write.assert_has_calls(expected_writes)
+    assert end_in.read.call_count == 6
+    assert len(content) == 512
+
+
+def test_reboot():
+    """Test that we can reboot a BOOTSEL board."""
+    end_out = mock.MagicMock()
+    pico.reboot(end_out)
+
+    payload = struct.pack('<LLBBxxLLLL4x', 0x431fd10b, 1, 0x2, 12, 0, 0, 0x20042000, 500)
+    end_out.write.assert_called_with(payload)

--- a/tests/test_pico.py
+++ b/tests/test_pico.py
@@ -52,6 +52,16 @@ def test_exit_xip():
     end_in.read.assert_called_once()
 
 
+def test_erase():
+    """Test that we can send a command to erase a section of memory."""
+    end_out, end_in = mock.MagicMock(), mock.MagicMock()
+    pico.erase(end_out, end_in, 0x101FE000, 8192)
+
+    payload = struct.pack('<LLBBxxLLL8x', 0x431fd10b, 1, 0x3, 8, 0, 0x101FE000, 8192)
+    end_out.write.assert_called_with(payload)
+    end_in.read.assert_called_once()
+
+
 def test_read():
     """Test that we can read a memory of a BOOTSEL board in a variety of conditions."""
     end_out, end_in = mock.MagicMock(), mock.MagicMock()

--- a/tests/test_pico.py
+++ b/tests/test_pico.py
@@ -126,3 +126,21 @@ def test_reboot():
 
     payload = struct.pack('<LLBBxxLLLL4x', 0x431fd10b, 1, 0x2, 12, 0, 0, 0x20042000, 500)
     end_out.write.assert_called_with(payload)
+
+
+def test_write():
+    """Test that we can write to a board in BOOTSEL mode."""
+    end_out, end_in = mock.MagicMock(), mock.MagicMock()
+    _ = pico.write(end_out, end_in, 0x101FE000, b'\x00\x01\x02\x03')
+
+    expected_writes = [
+        mock.call(struct.pack('<LLBBxxLL12x', 0x431fd10b, 1, 0x1, 1, 0, 1)),
+        mock.call(struct.pack('<LLBBxxL16x', 0x431fd10b, 1, 0x6, 0, 0)),
+        mock.call(struct.pack('<LLBBxxLLL8x', 0x431fd10b, 1, 0x3, 8, 0, 0x101FE000, 4)),
+        mock.call(struct.pack('<LLBBxxL16x', 0x431fd10b, 1, 0x6, 0, 0)),
+        mock.call(struct.pack('<LLBBxxLLL8x', 0x431fd10b, 1, 0x5, 8, 4, 0x101FE000, 4)),
+        mock.call(b'\x00\x01\x02\x03'),
+        mock.call(struct.pack('<LLBBxxLL12x', 0x431fd10b, 1, 0x1, 1, 0, 0)),
+    ]
+    end_out.write.assert_has_calls(expected_writes)
+    assert end_in.read.call_count == 6


### PR DESCRIPTION
This adds a direct USB mode to a couple of the tools, most notably the configuration editor, so you can make changes to the board when it is in BOOTSEL mode.

Implemented:

* `edit-config --usb`, read and write the configuration from/to USB
* `dump-config`, new tool which pretty much just mirrors `picotool save` of the config section, but without padding
* `visualize-storage --usb` which reads straight from the board